### PR TITLE
feat(auth): implement student registration, cpf/birthdate validation,…

### DIFF
--- a/app/src/main/java/com/fitcore/auth/application/service/AuthService.kt
+++ b/app/src/main/java/com/fitcore/auth/application/service/AuthService.kt
@@ -10,25 +10,26 @@ import com.fitcore.auth.domain.model.User
 import com.fitcore.auth.domain.model.UserRole
 import com.fitcore.auth.domain.port.`in`.AuthUseCase
 import com.fitcore.auth.domain.port.out.UserRepositoryPort
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 
 @Service
 class AuthService(
-    private val userRepositoryPort: UserRepositoryPort
+    private val userRepositoryPort: UserRepositoryPort,
+    private val passwordEncoder: PasswordEncoder
 ) : AuthUseCase {
 
-override fun login(request: LoginRequest): LoginResponse {
-    val user = userRepositoryPort.findByEmail(request.email)
-        ?: throw IllegalArgumentException("User not found")
+    override fun login(request: LoginRequest): LoginResponse {
+        val user = userRepositoryPort.findByEmail(request.email)
+            ?: throw IllegalArgumentException("User not found")
 
-    if (user.password != request.password) {
-        throw IllegalArgumentException("Invalid password")
+        if (!passwordEncoder.matches(request.password, user.password)) {
+            throw IllegalArgumentException("Invalid password")
+        }
+
+        val token = JwtUtil.generateToken(user.id!!, user.role.name)
+        return LoginResponse(token = token)
     }
-
-    val token = JwtUtil.generateToken(user.id!!, user.role.name)
-    return LoginResponse(token = token)
-}
-
 
     override fun register(request: RegisterRequest): RegisterResponse {
         if (userRepositoryPort.findByEmail(request.email) != null) {
@@ -37,8 +38,10 @@ override fun login(request: LoginRequest): LoginResponse {
         val user = User(
             name = request.name,
             email = request.email,
-            password = request.password,
+            password = passwordEncoder.encode(request.password),
             role = UserRole.valueOf(request.role),
+            cpf = request.cpf,
+            birthDate = request.birthDate
         )
         val saved = userRepositoryPort.save(user)
         return RegisterResponse(

--- a/app/src/main/java/com/fitcore/auth/application/service/StudentService.kt
+++ b/app/src/main/java/com/fitcore/auth/application/service/StudentService.kt
@@ -1,0 +1,32 @@
+package com.fitcore.auth.application.service
+
+import com.fitcore.auth.adapter.web.dto.RegisterStudentRequest
+import com.fitcore.auth.adapter.web.dto.UserResponse
+import com.fitcore.auth.domain.model.User
+import com.fitcore.auth.domain.model.UserRole
+import com.fitcore.auth.domain.port.out.UserRepositoryPort
+import org.springframework.stereotype.Service
+
+@Service
+class StudentService(
+    private val userRepositoryPort: UserRepositoryPort
+) {
+    fun registerStudent(request: RegisterStudentRequest): UserResponse {
+        if (userRepositoryPort.findByEmail(request.email) != null) {
+            throw IllegalArgumentException("E-mail already registered")
+        }
+        if (userRepositoryPort.findAll().any { it.cpf == request.cpf }) {
+            throw IllegalArgumentException("CPF already registered")
+        }
+        val user = User(
+            name = request.name,
+            email = request.email,
+            password = request.password,
+            role = UserRole.STUDENT,
+            cpf = request.cpf,
+            birthDate = request.birthDate
+        )
+        val saved = userRepositoryPort.save(user)
+        return UserResponse.fromDomain(saved)
+    }
+}

--- a/app/src/main/java/com/fitcore/auth/application/service/TokenBlacklistService.kt
+++ b/app/src/main/java/com/fitcore/auth/application/service/TokenBlacklistService.kt
@@ -1,3 +1,5 @@
+package com.fitcore.auth.application.service
+
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import java.util.concurrent.ConcurrentHashMap

--- a/app/src/main/java/com/fitcore/auth/domain/model/User.kt
+++ b/app/src/main/java/com/fitcore/auth/domain/model/User.kt
@@ -3,7 +3,8 @@ package com.fitcore.auth.domain.model
 enum class UserRole {
     ADMIN,
     SECRETARY,
-    TEACHER
+    TEACHER,
+    STUDENT
 }
 
 data class User(
@@ -12,6 +13,9 @@ data class User(
     val email: String,
     val password: String,
     val role: UserRole,
+    val cpf: String? = null,       
+    val birthDate: String? = null,
     val createdAt: Long = System.currentTimeMillis(),
     val updatedAt: Long = System.currentTimeMillis()
 )
+

--- a/app/src/main/java/com/fitcore/auth/infrastructure/persistence/adapter/UserPersistenceAdapter.kt
+++ b/app/src/main/java/com/fitcore/auth/infrastructure/persistence/adapter/UserPersistenceAdapter.kt
@@ -34,7 +34,9 @@ class UserPersistenceAdapter(
             password = user.password,
             role = user.role.name,
             createdAt = user.createdAt,
-            updatedAt = user.updatedAt
+            updatedAt = user.updatedAt,
+            cpf = user.cpf,
+            birthDate = user.birthDate
         )
         val saved = userJpaRepository.save(entity)
         return saved.toDomain()

--- a/app/src/main/java/com/fitcore/auth/infrastructure/persistence/adapter/web/controller/StudentController.kt
+++ b/app/src/main/java/com/fitcore/auth/infrastructure/persistence/adapter/web/controller/StudentController.kt
@@ -1,0 +1,32 @@
+package com.fitcore.auth.adapter.web.controller
+
+import com.fitcore.auth.adapter.web.dto.RegisterStudentRequest
+import com.fitcore.auth.adapter.web.dto.UserResponse
+import com.fitcore.auth.application.service.StudentService
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.server.ResponseStatusException
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.context.SecurityContextHolder
+
+@RestController
+@RequestMapping("/students")
+class StudentController(
+    private val studentService: StudentService
+) {
+    private val logger = LoggerFactory.getLogger(StudentController::class.java)
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('SECRETARY')")
+    @PostMapping("/register")
+    fun registerStudent(@RequestBody request: RegisterStudentRequest): ResponseEntity<UserResponse> {
+        val authentication = SecurityContextHolder.getContext().authentication
+        val userDetails = authentication.principal as? com.fitcore.auth.infrastructure.security.JwtUserDetails
+        if (userDetails?.role == "TEACHER") {
+            logger.warn("Access blocked: teacher attempted to register a student. id=${userDetails.id}")
+            throw ResponseStatusException(HttpStatus.FORBIDDEN, "Teachers are not allowed to register students.")
+        }
+        return ResponseEntity.ok(studentService.registerStudent(request))
+    }
+}

--- a/app/src/main/java/com/fitcore/auth/infrastructure/persistence/adapter/web/dto/RegisterRequest.kt
+++ b/app/src/main/java/com/fitcore/auth/infrastructure/persistence/adapter/web/dto/RegisterRequest.kt
@@ -4,5 +4,7 @@ data class RegisterRequest(
     val name: String,
     val email: String,
     val password: String,
-    val role: String
+    val role: String,
+    val cpf: String? = null,
+    val birthDate: String? = null
 )

--- a/app/src/main/java/com/fitcore/auth/infrastructure/persistence/adapter/web/dto/RegisterStudentRequest.kt
+++ b/app/src/main/java/com/fitcore/auth/infrastructure/persistence/adapter/web/dto/RegisterStudentRequest.kt
@@ -1,0 +1,9 @@
+package com.fitcore.auth.adapter.web.dto
+
+data class RegisterStudentRequest(
+    val name: String,
+    val email: String,
+    val password: String,
+    val cpf: String,
+    val birthDate: String 
+)

--- a/app/src/main/java/com/fitcore/auth/infrastructure/persistence/adapter/web/dto/UserResponse.kt
+++ b/app/src/main/java/com/fitcore/auth/infrastructure/persistence/adapter/web/dto/UserResponse.kt
@@ -8,7 +8,9 @@ data class UserResponse(
     val email: String,
     val role: String,
     val createdAt: Long,
-    val updatedAt: Long
+    val updatedAt: Long,
+    val cpf: String?,
+    val birthDate: String?
 ) {
     companion object {
         fun fromDomain(user: User) = UserResponse(
@@ -17,7 +19,9 @@ data class UserResponse(
             email = user.email,
             role = user.role.name,
             createdAt = user.createdAt,
-            updatedAt = user.updatedAt
+            updatedAt = user.updatedAt,
+            cpf = user.cpf,
+            birthDate = user.birthDate
         )
     }
 }

--- a/app/src/main/java/com/fitcore/auth/infrastructure/persistence/entity/UserEntity.kt
+++ b/app/src/main/java/com/fitcore/auth/infrastructure/persistence/entity/UserEntity.kt
@@ -12,9 +12,11 @@ data class UserEntity(
     val password: String = "",
     val role: String = "",
     val createdAt: Long = System.currentTimeMillis(),
-    val updatedAt: Long = System.currentTimeMillis()
+    val updatedAt: Long = System.currentTimeMillis(),
+    val cpf: String? = null,
+    val birthDate: String? = null
 ) {
-    constructor() : this(null, "", "", "", "", System.currentTimeMillis(), System.currentTimeMillis())
+    constructor() : this(null, "", "", "", "", System.currentTimeMillis(), System.currentTimeMillis(), null, null)
     fun toDomain() = com.fitcore.auth.domain.model.User(
         id = id,
         name = name,
@@ -22,6 +24,8 @@ data class UserEntity(
         password = password,
         role = com.fitcore.auth.domain.model.UserRole.valueOf(role),
         createdAt = createdAt,
-        updatedAt = updatedAt
+        updatedAt = updatedAt,
+        cpf = cpf,
+        birthDate = birthDate
     )
 }

--- a/app/src/main/java/com/fitcore/auth/infrastructure/persistence/mapper/UserMapper.kt
+++ b/app/src/main/java/com/fitcore/auth/infrastructure/persistence/mapper/UserMapper.kt
@@ -12,7 +12,9 @@ object UserMapper {
         password = entity.password,
         role = UserRole.valueOf(entity.role),
         createdAt = entity.createdAt,
-        updatedAt = entity.updatedAt
+        updatedAt = entity.updatedAt,
+        cpf = entity.cpf,
+        birthDate = entity.birthDate
     )
 
     fun toEntity(domain: User): UserEntity = UserEntity(
@@ -22,6 +24,8 @@ object UserMapper {
         password = domain.password,
         role = domain.role.name,
         createdAt = domain.createdAt,
-        updatedAt = domain.updatedAt
+        updatedAt = domain.updatedAt,
+        cpf = domain.cpf,
+        birthDate = domain.birthDate
     )
 }

--- a/app/src/main/java/com/fitcore/auth/infrastructure/security/JwtAuthFilter.kt
+++ b/app/src/main/java/com/fitcore/auth/infrastructure/security/JwtAuthFilter.kt
@@ -1,6 +1,7 @@
 package com.fitcore.auth.infrastructure.security
 
 import com.fitcore.auth.application.service.TokenBlacklistService
+import org.springframework.security.core.authority.SimpleGrantedAuthority
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -24,13 +25,18 @@ class JwtAuthFilter(
             if (tokenBlacklistService.isTokenBlacklisted(token)) {
                 response.status = HttpServletResponse.SC_UNAUTHORIZED
                 response.contentType = "application/json"
-                response.writer.write("{\"error\": \"Token inválido. Faça login novamente.\"}")
+                response.writer.write("{\"error\": \"Invalid token. Please log in again.\"}")
                 response.writer.flush()
                 return
             }
             if (JwtUtil.isValid(token)) {
                 val userId = JwtUtil.getUserIdFromToken(token)
-                val authentication = UsernamePasswordAuthenticationToken(userId, null, emptyList())
+                val role = JwtUtil.getRoleFromToken(token)
+                val authorities = listOf(SimpleGrantedAuthority("ROLE_$role"))
+                val userDetails = JwtUserDetails(userId, role, authorities)
+                val authentication = UsernamePasswordAuthenticationToken(
+                    userDetails, null, authorities
+                )
                 authentication.details = WebAuthenticationDetailsSource().buildDetails(request)
                 SecurityContextHolder.getContext().authentication = authentication
             }

--- a/app/src/main/java/com/fitcore/auth/infrastructure/security/JwtUserDetails.kt
+++ b/app/src/main/java/com/fitcore/auth/infrastructure/security/JwtUserDetails.kt
@@ -1,0 +1,18 @@
+package com.fitcore.auth.infrastructure.security
+
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.userdetails.UserDetails
+
+data class JwtUserDetails(
+    val id: Long,
+    val role: String,
+    private val authorities: Collection<GrantedAuthority>
+) : UserDetails {
+    override fun getAuthorities(): Collection<GrantedAuthority> = authorities
+    override fun getPassword(): String? = null
+    override fun getUsername(): String = id.toString()
+    override fun isAccountNonExpired(): Boolean = true
+    override fun isAccountNonLocked(): Boolean = true
+    override fun isCredentialsNonExpired(): Boolean = true
+    override fun isEnabled(): Boolean = true
+}

--- a/app/src/main/java/com/fitcore/auth/infrastructure/security/SecurityConfig.kt
+++ b/app/src/main/java/com/fitcore/auth/infrastructure/security/SecurityConfig.kt
@@ -4,6 +4,8 @@ import com.fitcore.auth.application.service.TokenBlacklistService
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
@@ -20,11 +22,13 @@ class SecurityConfig(
                     .requestMatchers("/auth/**").permitAll()
                     .anyRequest().authenticated()
             }
-
             .addFilterBefore(
-                JwtAuthFilter(tokenBlacklistService), 
+                JwtAuthFilter(tokenBlacklistService),
                 UsernamePasswordAuthenticationFilter::class.java
             )
         return http.build()
     }
+
+    @Bean
+    fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
 }


### PR DESCRIPTION
… role-based access, and password hashing

- Add Student role and update domain/user model for student registration
- Only Admin and Secretary can register students
- Add CPF as registration ID and birthDate for students
- Validate unique email and CPF on registration
- Implement password hashing with BCrypt
- Refactor security config and filter to support new flows